### PR TITLE
Fix hostname deprecation

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,8 +41,8 @@ object if something goes wrong.
     `$port` defaults to 25, and defines what port to connect to on the remote
     server.
 
-    `$hostname` defaults to calling `gethostname()`, and determines the hostname
-    given to the server in the initial HELO or EHLO message
+    `$hostname` defaults to calling `$*KERNEL.hostname()`, and determines the
+    hostname given to the server in the initial HELO or EHLO message
 
     `$debug` when set to a true value, will print the SMTP traffic to stderr.
 
@@ -124,8 +124,8 @@ object if something goes wrong.
     
  -  `get-response`
  -  `send($stuff)`
- -  `ehlo($hostname = gethostname())`
- -  `helo($hostname = gethostname())`
+ -  `ehlo($hostname = $*KERNEL.hostname())`
+ -  `helo($hostname = $*KERNEL.hostname())`
  -  `starttls()`
  -  `switch-to-ssl()`
  -  `auth-login($username, $password)`

--- a/lib/Net/SMTP.pm6
+++ b/lib/Net/SMTP.pm6
@@ -34,7 +34,7 @@ method new(:$server!, :$port = 25, :$raw, :$debug, :$hostname, :$socket = IO::So
         $self.conn.nl-in = "\r\n";
     } else {
         $self does Net::SMTP::Simple;
-        $self.hostname = $hostname // gethostname;
+        $self.hostname = $hostname // $*KERNEL.hostname();
         my $started = $self.start;
         unless $started {
             return $started;

--- a/lib/Net/SMTP/Raw.pm6
+++ b/lib/Net/SMTP/Raw.pm6
@@ -22,11 +22,11 @@ method send($stuff) {
     return self.get-response;
 }
 
-method ehlo($hostname = gethostname()) {
+method ehlo($hostname = $*KERNEL.hostname()) {
     return self.send("EHLO $hostname");
 }
 
-method helo($hostname = gethostname()) {
+method helo($hostname = $*KERNEL.hostname()) {
     return self.send("HELO $hostname");
 }
 


### PR DESCRIPTION
This builds on the work of @vendethiel to fix references to `gethostname` in the documentation as well as in the default arguments of `Raw.pm6`.